### PR TITLE
Better handle errors when unable to parse an atom

### DIFF
--- a/chem_interactions/ChemicalInteractions.py
+++ b/chem_interactions/ChemicalInteractions.py
@@ -174,9 +174,9 @@ class ChemicalInteractions(nanome.AsyncPluginInstance):
 
         notification_txt = f"Finished Calculating Interactions!\n{len(all_new_lines)} lines added"
         if parse_errors:
-            self.send_notification(
-                enums.NotificationTypes.warning,
-                "Some interaction results could not be parsed. Check logs for details.")
+            msg = "Some interaction results could not be parsed. Check logs for details."
+            self.send_notification(enums.NotificationTypes.warning, msg)
+            Logs.warning(msg)
         asyncio.create_task(self.send_async_notification(notification_txt))
 
     @staticmethod
@@ -289,8 +289,6 @@ class ChemicalInteractions(nanome.AsyncPluginInstance):
             return
 
         if len(atoms) > 1:
-            # If too many atoms found, only look at specified chain name (No heteroatoms)
-            Logs.warning("More than one atom found for atom path {}. Filtering heteroatom chains".format(atom_path))
             atoms = [
                 a for a in complex_molecule.atoms
                 if all([

--- a/chem_interactions/ChemicalInteractions.py
+++ b/chem_interactions/ChemicalInteractions.py
@@ -176,7 +176,7 @@ class ChemicalInteractions(nanome.AsyncPluginInstance):
         if parse_errors:
             self.send_notification(
                 enums.NotificationTypes.warning,
-                "Some interactions could not be rendered. See logs for details.")
+                "Some interaction results could not be parsed. Check logs for details.")
         asyncio.create_task(self.send_async_notification(notification_txt))
 
     @staticmethod

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -84,12 +84,13 @@ class PluginFunctionTestCase(unittest.TestCase):
         # Known value from 1tyl_contacts_data.json
         expected_line_count = 86
         loop = asyncio.get_event_loop()
-        line_manager = loop.run_until_complete(
+        line_manager, errors = loop.run_until_complete(
             self.plugin_instance.parse_contacts_data(
                 contacts_data, [self.complex], default_line_settings
             )
         )
         self.assertEqual(len(line_manager.all_lines()), expected_line_count)
+        self.assertEqual(errors, False)
 
     def test_run_arpeggio(self):
         with open(f'{fixtures_dir}/1tyl_ligand_selections.json') as f:


### PR DESCRIPTION
- Don't fail whole run if an atom isn't found.
- Display all other interactions, and send warning notification to check the logs